### PR TITLE
[ADS-28] Links component

### DIFF
--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.html
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.html
@@ -385,6 +385,7 @@
       [innerHTML]="text | sanitize"
     ></a>
   </ng-container>
+  <!-- Link component -->
   <ng-container *ngSwitchCase="'link'">
     <a
       *ngIf="route"
@@ -410,9 +411,8 @@
           left: linkIcon?.position === 'right',
           right: linkIcon?.position === 'left'
         }"
-      >
-        {{ text }}
-      </span>
+        [innerHTML]="text | sanitize"
+      ></span>
       <i
         aria-hidden="true"
         *ngIf="linkIcon && linkIcon.name"
@@ -427,7 +427,7 @@
       <i
         aria-hidden="true"
         *ngIf="linkIcon && linkIcon.template"
-        class="link__icon"
+        class="link__icon link__icon--template"
         [ngClass]="{
           left: linkIcon.position === 'left',
           right: linkIcon.position === 'right'

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.html
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.html
@@ -211,7 +211,9 @@
   ></blockquote>
   <span
     *ngSwitchCase="'numbers-1'"
-    [class]="'numbers numbers-1 typography ' + (presetClassNames | array2string)"
+    [class]="
+      'numbers numbers-1 typography ' + (presetClassNames | array2string)
+    "
     [ngClass]="{
       'preset-variant--heading-1': presetVariant === 'heading-1',
       'preset-variant--heading-2': presetVariant === 'heading-2',
@@ -226,7 +228,9 @@
   ></span>
   <span
     *ngSwitchCase="'numbers-2'"
-    [class]="'numbers numbers-2 typography ' + (presetClassNames | array2string)"
+    [class]="
+      'numbers numbers-2 typography ' + (presetClassNames | array2string)
+    "
     [ngClass]="{
       'preset-variant--heading-1': presetVariant === 'heading-1',
       'preset-variant--heading-2': presetVariant === 'heading-2',
@@ -241,7 +245,9 @@
   ></span>
   <span
     *ngSwitchCase="'numbers-3'"
-    [class]="'numbers numbers-3 typography ' + (presetClassNames | array2string)"
+    [class]="
+      'numbers numbers-3 typography ' + (presetClassNames | array2string)
+    "
     [ngClass]="{
       'preset-variant--heading-1': presetVariant === 'heading-1',
       'preset-variant--heading-2': presetVariant === 'heading-2',
@@ -256,7 +262,9 @@
   ></span>
   <span
     *ngSwitchCase="'numbers-4'"
-    [class]="'numbers numbers-4 typography ' + (presetClassNames | array2string)"
+    [class]="
+      'numbers numbers-4 typography ' + (presetClassNames | array2string)
+    "
     [ngClass]="{
       'preset-variant--heading-1': presetVariant === 'heading-1',
       'preset-variant--heading-2': presetVariant === 'heading-2',
@@ -271,7 +279,9 @@
   ></span>
   <span
     *ngSwitchCase="'numbers-5'"
-    [class]="'numbers numbers-5 typography ' + (presetClassNames | array2string)"
+    [class]="
+      'numbers numbers-5 typography ' + (presetClassNames | array2string)
+    "
     [ngClass]="{
       'preset-variant--heading-1': presetVariant === 'heading-1',
       'preset-variant--heading-2': presetVariant === 'heading-2',
@@ -375,52 +385,92 @@
       [innerHTML]="text | sanitize"
     ></a>
   </ng-container>
+  <ng-container *ngSwitchCase="'link'">
+    <a
+      *ngIf="route"
+      [routerLink]="route"
+      [attr.id]="idName || null"
+      [tabindex]="disabled ? -1 : 0"
+      [attr.aria-disabled]="disabled || null"
+      class="link"
+      [ngClass]="{
+        'link--disabled': disabled,
+        'link--standalone': linkStandalone,
+        'link--size-small': linkSize === 'small',
+        'link--size-medium': linkSize === 'medium',
+        'link--size-large': linkSize === 'large'
+      }"
+    >
+      <span
+        class="link__label"
+        [ngClass]="{
+          'text-preset-9--medium': linkSize === 'small',
+          'text-preset-8--medium': linkSize === 'medium',
+          'text-preset-7--medium': linkSize === 'large',
+          left: linkIcon?.position === 'right',
+          right: linkIcon?.position === 'left'
+        }"
+      >
+        {{ text }}
+      </span>
+      <i
+        aria-hidden="true"
+        *ngIf="linkIcon && linkIcon.name"
+        class="link__icon"
+        [ngClass]="{
+          left: linkIcon.position === 'left',
+          right: linkIcon.position === 'right'
+        }"
+      >
+        <aus-icon [name]="linkIcon.name"></aus-icon>
+      </i>
+      <i
+        aria-hidden="true"
+        *ngIf="linkIcon && linkIcon.template"
+        class="link__icon"
+        [ngClass]="{
+          left: linkIcon.position === 'left',
+          right: linkIcon.position === 'right'
+        }"
+        [innerHTML]="linkIcon.template || '' | sanitize"
+      ></i>
+    </a>
+  </ng-container>
 </ng-container>
 <ng-container *ngIf="loading" [ngSwitch]="variant">
-  <h1
-    class="typography h1"
-    *ngIf="variant === 'h1' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></h1>
-  <h2
-    class="typography h2"
-    *ngIf="variant === 'h2' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></h2>
-  <h3
-    class="typography h3"
-    *ngIf="variant === 'h3' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></h3>
-  <h4
-    class="typography h4"
-    *ngIf="variant === 'h4' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></h4>
-  <h5
-    class="typography h5"
-    *ngIf="variant === 'h5' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></h5>
-  <h6
-    class="typography h6"
-    *ngIf="variant === 'h6' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></h6>
-  <p
-    class="typography p"
-    *ngIf="variant === 'p' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></p>
-  <p
-    class="p-xs typography p"
-    *ngIf="variant === 'p-xs' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></p>
-  <p
-    class="p-sm typography p"
-    *ngIf="variant === 'p-sm' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></p>
-  <p
-    *ngIf="variant === 'p-md' && loading"
-    class="p-md typography p"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></p>
-  <span
-    class="typography span"
-    *ngIf="variant === 'span' && loading"
-  ><ng-container *ngTemplateOutlet="SKELETON"></ng-container></span>
+  <h1 class="typography h1" *ngIf="variant === 'h1' && loading">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </h1>
+  <h2 class="typography h2" *ngIf="variant === 'h2' && loading">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </h2>
+  <h3 class="typography h3" *ngIf="variant === 'h3' && loading">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </h3>
+  <h4 class="typography h4" *ngIf="variant === 'h4' && loading">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </h4>
+  <h5 class="typography h5" *ngIf="variant === 'h5' && loading">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </h5>
+  <h6 class="typography h6" *ngIf="variant === 'h6' && loading">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </h6>
+  <p class="typography p" *ngIf="variant === 'p' && loading">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </p>
+  <p class="p-xs typography p" *ngIf="variant === 'p-xs' && loading">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </p>
+  <p class="p-sm typography p" *ngIf="variant === 'p-sm' && loading">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </p>
+  <p *ngIf="variant === 'p-md' && loading" class="p-md typography p">
+    <ng-container *ngTemplateOutlet="SKELETON"></ng-container>
+  </p>
+  <span class="typography span" *ngIf="variant === 'span' && loading"
+    ><ng-container *ngTemplateOutlet="SKELETON"></ng-container
+  ></span>
 </ng-container>
 
 <ng-template #SKELETON>

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.model.ts
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.model.ts
@@ -20,7 +20,8 @@ export type TypographyComponentVariants =
   | 'numbers-3'
   | 'numbers-4'
   | 'numbers-5'
-  | 'code';
+  | 'code'
+  | 'link';
 
 export type TypographyComponentWeights = '400' | '500' | '700';
 

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.scss
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.scss
@@ -329,16 +329,17 @@
   }
 
   // New 'Link' component
-  .link {
+  .link,
+  ::ng-deep .link {
     display: inline-flex;
     align-items: center;
     justify-content: flex-start;
     text-decoration: underline;
     &__label {
+      font-weight: 500;
       transition: all 0.25s;
       text-decoration: underline;
       color: map-get($colors, primary, brand);
-      transform: translateY(2px);
       &.left {
         order: 0;
       }
@@ -350,8 +351,33 @@
       display: inline-flex;
       align-items: flex-start;
       justify-content: center;
-      ::ng-deep svg path {
-        transition: all 0.25s;
+      ::ng-deep {
+        svg path,
+        .icon {
+          transition: all 0.25s;
+          fill: map-get($colors, primary, brand);
+          color: map-get($colors, primary, brand);
+        }
+        aus-icon {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+        }
+      }
+      &:not(.link__icon--template) {
+        ::ng-deep {
+          svg {
+            width: 0.875em !important;
+            height: 0.875em !important;
+            transform: translateY(-2px);
+            @include iota-breakpoint(md) {
+              transform: translateY(-1px);
+            }
+          }
+        }
+      }
+      &--template {
+        transform: translateY(-2px);
       }
       &.left {
         order: 0;
@@ -368,8 +394,12 @@
         &__label {
           color: map-get($colors, primary, medium);
         }
-        &__icon ::ng-deep svg path {
-          fill: map-get($colors, primary, medium);
+        &__icon ::ng-deep {
+          svg path,
+          .icon {
+            fill: map-get($colors, primary, medium);
+            color: map-get($colors, primary, medium);
+          }
         }
       }
     }
@@ -378,8 +408,12 @@
         &__label {
           color: map-get($colors, neutral, black);
         }
-        &__icon ::ng-deep svg path {
-          fill: map-get($colors, neutral, black);
+        &__icon ::ng-deep {
+          svg path,
+          .icon {
+            fill: map-get($colors, neutral, black);
+            color: map-get($colors, neutral, black);
+          }
         }
       }
     }
@@ -397,8 +431,12 @@
         &__label {
           color: map-get($colors, neutral, black);
         }
-        &__icon ::ng-deep svg path {
-          fill: map-get($colors, neutral, black);
+        &__icon ::ng-deep {
+          svg path,
+          .icon {
+            fill: map-get($colors, neutral, black);
+            color: map-get($colors, neutral, black);
+          }
         }
       }
     }
@@ -414,6 +452,15 @@
       &-small {
         .link {
           &__icon {
+            ::ng-deep {
+              svg {
+                width: 12px;
+                height: 12px;
+              }
+              .icon {
+                font-size: 20px;
+              }
+            }
             &.left {
               margin-right: 6px;
             }
@@ -426,6 +473,15 @@
       &-medium {
         .link {
           &__icon {
+            ::ng-deep {
+              svg {
+                width: 15px;
+                height: 15px;
+              }
+              .icon {
+                font-size: 22px;
+              }
+            }
             &.left {
               margin-right: 7px;
             }
@@ -438,6 +494,15 @@
       &-large {
         .link {
           &__icon {
+            ::ng-deep {
+              svg {
+                width: 18px;
+                height: 18px;
+              }
+              .icon {
+                font-size: 25px;
+              }
+            }
             &.left {
               margin-right: 8px;
             }
@@ -448,14 +513,19 @@
         }
       }
     }
-    &--disabled {
+    &--disabled,
+    &--disabled:visited {
       pointer-events: none;
       .link {
         &__label {
           color: map-get($colors, neutral, 06);
         }
-        &__icon ::ng-deep svg path {
-          fill: map-get($colors, neutral, 06);
+        &__icon ::ng-deep {
+          svg path,
+          .icon {
+            fill: map-get($colors, neutral, 06);
+            color: map-get($colors, neutral, 06);
+          }
         }
       }
     }

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.scss
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.scss
@@ -327,6 +327,139 @@
       )
     );
   }
+
+  // New 'Link' component
+  .link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    text-decoration: underline;
+    &__label {
+      transition: all 0.25s;
+      text-decoration: underline;
+      color: map-get($colors, primary, brand);
+      transform: translateY(2px);
+      &.left {
+        order: 0;
+      }
+      &.right {
+        order: 1;
+      }
+    }
+    &__icon {
+      display: inline-flex;
+      align-items: flex-start;
+      justify-content: center;
+      ::ng-deep svg path {
+        transition: all 0.25s;
+      }
+      &.left {
+        order: 0;
+      }
+      &.right {
+        order: 1;
+      }
+    }
+    &:before {
+      display: none;
+    }
+    &:visited {
+      .link {
+        &__label {
+          color: map-get($colors, primary, medium);
+        }
+        &__icon ::ng-deep svg path {
+          fill: map-get($colors, primary, medium);
+        }
+      }
+    }
+    &:hover {
+      .link {
+        &__label {
+          color: map-get($colors, neutral, black);
+        }
+        &__icon ::ng-deep svg path {
+          fill: map-get($colors, neutral, black);
+        }
+      }
+    }
+    &:focus {
+      border: 0;
+      box-shadow: none;
+    }
+    &:focus-visible {
+      border: 0;
+      box-shadow: none;
+      border-radius: 8px;
+      outline-offset: 2px;
+      outline: 2px solid map-get($colors, support, focus);
+      .link {
+        &__label {
+          color: map-get($colors, neutral, black);
+        }
+        &__icon ::ng-deep svg path {
+          fill: map-get($colors, neutral, black);
+        }
+      }
+    }
+    &--standalone {
+      text-decoration: none;
+      .link {
+        &__label {
+          text-decoration: none;
+        }
+      }
+    }
+    &--size {
+      &-small {
+        .link {
+          &__icon {
+            &.left {
+              margin-right: 6px;
+            }
+            &.right {
+              margin-left: 6px;
+            }
+          }
+        }
+      }
+      &-medium {
+        .link {
+          &__icon {
+            &.left {
+              margin-right: 7px;
+            }
+            &.right {
+              margin-left: 7px;
+            }
+          }
+        }
+      }
+      &-large {
+        .link {
+          &__icon {
+            &.left {
+              margin-right: 8px;
+            }
+            &.right {
+              margin-left: 8px;
+            }
+          }
+        }
+      }
+    }
+    &--disabled {
+      pointer-events: none;
+      .link {
+        &__label {
+          color: map-get($colors, neutral, 06);
+        }
+        &__icon ::ng-deep svg path {
+          fill: map-get($colors, neutral, 06);
+        }
+      }
+    }
+  }
 }
 
 @include typography-base();

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.scss
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.scss
@@ -364,18 +364,6 @@
           justify-content: center;
         }
       }
-      &:not(.link__icon--template) {
-        ::ng-deep {
-          svg {
-            width: 0.875em !important;
-            height: 0.875em !important;
-            transform: translateY(-2px);
-            @include iota-breakpoint(md) {
-              transform: translateY(-1px);
-            }
-          }
-        }
-      }
       &--template {
         transform: translateY(-2px);
       }
@@ -445,6 +433,22 @@
       .link {
         &__label {
           text-decoration: none;
+        }
+      }
+    }
+    &--inline {
+      .link {
+        &__icon {
+          ::ng-deep {
+            svg {
+              width: 0.875em !important;
+              height: 0.875em !important;
+              transform: translateY(-2px);
+              @include iota-breakpoint(md) {
+                transform: translateY(-1px);
+              }
+            }
+          }
         }
       }
     }

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.ts
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.component.ts
@@ -1,3 +1,4 @@
+import { IconComponentNames } from "./../icon/icon.model";
 import { AfterViewInit, Component, ElementRef, Input } from "@angular/core";
 
 import {
@@ -32,6 +33,13 @@ export class TypographyComponent implements AfterViewInit {
   @Input() loading?: boolean = false;
   @Input() loadingData: LoadingData = {
     lines: 1,
+  };
+  @Input() linkStandalone?: boolean = false;
+  @Input() linkSize?: "small" | "medium" | "large" = "large";
+  @Input() linkIcon?: {
+    name?: IconComponentNames;
+    template?: string;
+    position: "left" | "right";
   };
   textSanitized: SafeHtml = "";
 

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.module.ts
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.module.ts
@@ -1,3 +1,4 @@
+import { IconModule } from "./../icon/icon.module";
 import { Array2StringPipeModule } from "./../../pipes/array2string/array2string.module";
 import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
@@ -12,6 +13,7 @@ import { TypographyComponent } from "./typography.component";
     RouterModule,
     SanitizePipeModule,
     Array2StringPipeModule,
+    IconModule,
   ],
   providers: [],
   exports: [TypographyComponent],

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
@@ -256,6 +256,6 @@ LinkStandaloneDisabled.args = {
 export const LinkInline = Template.bind({});
 LinkInline.args = {
   presetClassNames: ["text-preset-7"],
-  text: "This paragraph contains an <a href='#' class='link link--size-medium'><span class='link__label left'>Inline Link</span><i class='link__icon right'><svg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M16 16H2V2H9V0H2C0.89 0 0 0.9 0 2V16C0 17.1 0.89 18 2 18H16C17.1 18 18 17.1 18 16V9H16V16ZM11 0V2H14.59L4.76 11.83L6.17 13.24L16 3.41V7H18V0H11Z' fill='#EB002A'/></svg></i></a> with an icon and another without: <a href='/test' class='link'><span class='link__label'>Another Link</span></a>",
+  text: "This paragraph contains an <a href='#' class='link link--inline link--size-medium'><span class='link__label left'>Inline Link</span><i class='link__icon right'><svg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M16 16H2V2H9V0H2C0.89 0 0 0.9 0 2V16C0 17.1 0.89 18 2 18H16C17.1 18 18 17.1 18 16V9H16V16ZM11 0V2H14.59L4.76 11.83L6.17 13.24L16 3.41V7H18V0H11Z' fill='#EB002A'/></svg></i></a> with an icon and another without: <a href='/test' class='link'><span class='link__label'>Another Link</span></a>",
   route: "/test",
 };

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
@@ -1,3 +1,4 @@
+import { IconComponent } from "./../icon/icon.component";
 import { Array2StringPipe } from "./../../pipes/array2string/array2string.pipe";
 import { RouterTestingModule } from "@angular/router/testing";
 import { Story, Meta, moduleMetadata } from "@storybook/angular";
@@ -10,7 +11,12 @@ export default {
   component: TypographyComponent,
   decorators: [
     moduleMetadata({
-      declarations: [TypographyComponent, SanitizePipe, Array2StringPipe],
+      declarations: [
+        TypographyComponent,
+        SanitizePipe,
+        Array2StringPipe,
+        IconComponent,
+      ],
       imports: [RouterTestingModule],
     }),
   ],
@@ -154,8 +160,8 @@ LinkDisabled.args = {
   disabled: true,
 };
 
-export const StandaloneLink = Template.bind({});
-StandaloneLink.args = {
+export const StandaloneLinkWithTemplateIcon = Template.bind({});
+StandaloneLinkWithTemplateIcon.args = {
   variant: "link",
   text: "Standalone Link",
   route: "/test",
@@ -167,4 +173,25 @@ StandaloneLink.args = {
     position: "left",
   },
   disabled: false,
+};
+
+export const StandaloneLinkWithIconName = Template.bind({});
+StandaloneLinkWithIconName.args = {
+  variant: "link",
+  text: "Standalone Link",
+  route: "/test",
+  linkStandalone: true,
+  linkSize: "large",
+  linkIcon: {
+    name: "package",
+    position: "right",
+  },
+  disabled: false,
+};
+
+export const InlineLink = Template.bind({});
+InlineLink.args = {
+  variant: "p",
+  text: "This paragraph contains an <a href='#' class='link link--size-medium'><span class='link__label left'>Inline Link</span><i class='link__icon right'><svg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M16 16H2V2H9V0H2C0.89 0 0 0.9 0 2V16C0 17.1 0.89 18 2 18H16C17.1 18 18 17.1 18 16V9H16V16ZM11 0V2H14.59L4.76 11.83L6.17 13.24L16 3.41V7H18V0H11Z' fill='#EB002A'/></svg></i></a> with an icon and another without: <a href='/test' class='link'><span class='link__label'>Another Link</span></a>",
+  route: "/test",
 };

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
@@ -153,3 +153,18 @@ LinkDisabled.args = {
   route: "/test",
   disabled: true,
 };
+
+export const StandaloneLink = Template.bind({});
+StandaloneLink.args = {
+  variant: "link",
+  text: "Standalone Link",
+  route: "/test",
+  linkStandalone: true,
+  linkSize: "large",
+  linkIcon: {
+    template:
+      "<svg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M8 2C9.1 2 10 2.9 10 4C10 5.1 9.1 6 8 6C6.9 6 6 5.1 6 4C6 2.9 6.9 2 8 2ZM8 12C10.7 12 13.8 13.29 14 14H2C2.23 13.28 5.31 12 8 12ZM8 0C5.79 0 4 1.79 4 4C4 6.21 5.79 8 8 8C10.21 8 12 6.21 12 4C12 1.79 10.21 0 8 0ZM8 10C5.33 10 0 11.34 0 14V16H16V14C16 11.34 10.67 10 8 10Z' fill='#EB002A'/></svg>",
+    position: "left",
+  },
+  disabled: false,
+};

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
@@ -26,134 +26,134 @@ const Template: Story<TypographyComponent> = (args: TypographyComponent) => ({
   props: args,
 });
 
-export const Heading1 = Template.bind({});
-Heading1.args = {
+export const LegacyHeading1 = Template.bind({});
+LegacyHeading1.args = {
   variant: "h1",
   text: "Heading 1",
 };
 
-export const Heading1Custom = Template.bind({});
-Heading1Custom.args = {
+export const LegacyHeading1Custom = Template.bind({});
+LegacyHeading1Custom.args = {
   variant: "h1",
   weight: "400",
   color: "#00FF00",
   text: "Heading 1",
 };
 
-export const Heading2 = Template.bind({});
-Heading2.args = {
+export const LegacyHeading2 = Template.bind({});
+LegacyHeading2.args = {
   variant: "h2",
   text: "Heading 2",
 };
 
-export const Heading3 = Template.bind({});
-Heading3.args = {
+export const LegacyHeading3 = Template.bind({});
+LegacyHeading3.args = {
   variant: "h3",
   text: "Heading 3",
 };
 
-export const Heading4 = Template.bind({});
-Heading4.args = {
+export const LegacyHeading4 = Template.bind({});
+LegacyHeading4.args = {
   variant: "h4",
   text: "Heading 4",
 };
 
-export const Heading5 = Template.bind({});
-Heading5.args = {
+export const LegacyHeading5 = Template.bind({});
+LegacyHeading5.args = {
   variant: "h5",
   text: "Heading 5",
 };
 
-export const Heading6 = Template.bind({});
-Heading6.args = {
+export const LegacyHeading6 = Template.bind({});
+LegacyHeading6.args = {
   variant: "h6",
   text: "Heading 6",
 };
 
-export const Paragraph = Template.bind({});
-Paragraph.args = {
+export const LegacyParagraph = Template.bind({});
+LegacyParagraph.args = {
   variant: "p",
   text: "Paragraph",
 };
 
-export const Span = Template.bind({});
-Span.args = {
+export const LegacySpan = Template.bind({});
+LegacySpan.args = {
   variant: "span",
   text: "Span",
 };
 
-export const Blockquote = Template.bind({});
-Blockquote.args = {
+export const LegacyBlockquote = Template.bind({});
+LegacyBlockquote.args = {
   variant: "blockquote",
   text: "Blockquote",
 };
 
-export const FormText = Template.bind({});
-FormText.args = {
+export const LegacyFormText = Template.bind({});
+LegacyFormText.args = {
   variant: "form-text",
   text: "Form text",
   for: "test-id",
 };
 
-export const FormSmall = Template.bind({});
-FormSmall.args = {
+export const LegacyFormSmall = Template.bind({});
+LegacyFormSmall.args = {
   variant: "form-small",
   text: "Form small",
 };
 
-export const Numbers1 = Template.bind({});
-Numbers1.args = {
+export const LegacyNumbers1 = Template.bind({});
+LegacyNumbers1.args = {
   variant: "numbers-1",
   text: "999",
 };
 
-export const Numbers2 = Template.bind({});
-Numbers2.args = {
+export const LegacyNumbers2 = Template.bind({});
+LegacyNumbers2.args = {
   variant: "numbers-2",
   text: "999",
 };
 
-export const Numbers3 = Template.bind({});
-Numbers3.args = {
+export const LegacyNumbers3 = Template.bind({});
+LegacyNumbers3.args = {
   variant: "numbers-3",
   text: "999",
 };
 
-export const Numbers4 = Template.bind({});
-Numbers4.args = {
+export const LegacyNumbers4 = Template.bind({});
+LegacyNumbers4.args = {
   variant: "numbers-4",
   text: "999",
 };
 
-export const Numbers5 = Template.bind({});
-Numbers5.args = {
+export const LegacyNumbers5 = Template.bind({});
+LegacyNumbers5.args = {
   variant: "numbers-5",
   text: "999",
 };
 
-export const Link = Template.bind({});
-Link.args = {
+export const LegacyLink = Template.bind({});
+LegacyLink.args = {
   variant: "a",
   text: "View more",
   route: "/test",
 };
 
-export const LinkAccent = Template.bind({});
-LinkAccent.args = {
+export const LegacyLinkAccent = Template.bind({});
+LegacyLinkAccent.args = {
   variant: "a-accent",
   text: "See details",
   route: "/test",
 };
 
-export const LinkExternal = Template.bind({});
-LinkExternal.args = {
+export const LegacyLinkExternal = Template.bind({});
+LegacyLinkExternal.args = {
   variant: "a",
   text: "External link",
   href: "https://www.google.com",
 };
 
-export const LinkDisabled = Template.bind({});
-LinkDisabled.args = {
+export const LegacyLinkDisabled = Template.bind({});
+LegacyLinkDisabled.args = {
   variant: "a-accent",
   text: "Disabled link",
   route: "/test",

--- a/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
+++ b/projects/ngx-aus-design-system/src/lib/shared/components/typography/typography.stories.ts
@@ -160,8 +160,62 @@ LegacyLinkDisabled.args = {
   disabled: true,
 };
 
-export const StandaloneLinkWithTemplateIcon = Template.bind({});
-StandaloneLinkWithTemplateIcon.args = {
+export const Preset_1 = Template.bind({});
+Preset_1.args = {
+  text: "Hello world!",
+  presetClassNames: ["text-preset-1"],
+};
+
+export const Preset_2 = Template.bind({});
+Preset_2.args = {
+  text: "Hello world!",
+  presetClassNames: ["text-preset-2"],
+};
+
+export const Preset_3 = Template.bind({});
+Preset_3.args = {
+  text: "Hello world!",
+  presetClassNames: ["text-preset-3"],
+};
+
+export const Preset_4 = Template.bind({});
+Preset_4.args = {
+  text: "Hello world!",
+  presetClassNames: ["text-preset-4"],
+};
+
+export const Preset_5 = Template.bind({});
+Preset_5.args = {
+  text: "Hello world!",
+  presetClassNames: ["text-preset-5"],
+};
+
+export const Preset_6 = Template.bind({});
+Preset_6.args = {
+  text: "Hello world!",
+  presetClassNames: ["text-preset-6"],
+};
+
+export const Preset_7 = Template.bind({});
+Preset_7.args = {
+  text: "Hello world!",
+  presetClassNames: ["text-preset-7"],
+};
+
+export const Preset_8 = Template.bind({});
+Preset_8.args = {
+  text: "Hello world!",
+  presetClassNames: ["text-preset-8"],
+};
+
+export const Preset_9 = Template.bind({});
+Preset_9.args = {
+  text: "Hello world!",
+  presetClassNames: ["text-preset-9"],
+};
+
+export const LinkStandaloneWithIconTemplate = Template.bind({});
+LinkStandaloneWithIconTemplate.args = {
   variant: "link",
   text: "Standalone Link",
   route: "/test",
@@ -175,8 +229,8 @@ StandaloneLinkWithTemplateIcon.args = {
   disabled: false,
 };
 
-export const StandaloneLinkWithIconName = Template.bind({});
-StandaloneLinkWithIconName.args = {
+export const LinkStandaloneWithIconName = Template.bind({});
+LinkStandaloneWithIconName.args = {
   variant: "link",
   text: "Standalone Link",
   route: "/test",
@@ -189,9 +243,19 @@ StandaloneLinkWithIconName.args = {
   disabled: false,
 };
 
-export const InlineLink = Template.bind({});
-InlineLink.args = {
-  variant: "p",
+export const LinkStandaloneDisabled = Template.bind({});
+LinkStandaloneDisabled.args = {
+  variant: "link",
+  text: "Standalone Link",
+  route: "/test",
+  linkStandalone: true,
+  linkSize: "large",
+  disabled: true,
+};
+
+export const LinkInline = Template.bind({});
+LinkInline.args = {
+  presetClassNames: ["text-preset-7"],
   text: "This paragraph contains an <a href='#' class='link link--size-medium'><span class='link__label left'>Inline Link</span><i class='link__icon right'><svg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M16 16H2V2H9V0H2C0.89 0 0 0.9 0 2V16C0 17.1 0.89 18 2 18H16C17.1 18 18 17.1 18 16V9H16V16ZM11 0V2H14.59L4.76 11.83L6.17 13.24L16 3.41V7H18V0H11Z' fill='#EB002A'/></svg></i></a> with an icon and another without: <a href='/test' class='link'><span class='link__label'>Another Link</span></a>",
   route: "/test",
 };


### PR DESCRIPTION
- Implement `Link` component using `Typography` as base for both `inline` and `standalone` variants

### Preview
[Components-Shared-Typography---Link-Inline-⋅-Storybook.webm](https://user-images.githubusercontent.com/108202693/226060641-3ae0efa6-a391-404a-bc06-a89c6071b3f5.webm)